### PR TITLE
Provider azurm and interpolation syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+provider "azurerm" {
+  version         = "=2.10.0"
+  features {}
+}
+
 terraform {
   required_version = "> 0.12.0"
 
@@ -30,14 +35,14 @@ resource "random_integer" "app_service_name_suffix" {
 }
 
 resource "azurerm_resource_group" "spacegame" {
-  name     = "${var.resource_group_name}"
-  location = "${var.resource_group_location}"
+  name     = var.resource_group_name
+  location = var.resource_group_location
 }
 
 resource "azurerm_app_service_plan" "spacegame" {
-  name                = "${var.app_service_plan_name}"
-  location            = "${azurerm_resource_group.spacegame.location}"
-  resource_group_name = "${azurerm_resource_group.spacegame.name}"
+  name                = var.app_service_plan_name
+  location            = azurerm_resource_group.spacegame.location
+  resource_group_name = azurerm_resource_group.spacegame.name
   kind                = "Linux"
   reserved            = true
 
@@ -49,9 +54,9 @@ resource "azurerm_app_service_plan" "spacegame" {
 
 resource "azurerm_app_service" "spacegame_dev" {
   name                = "${var.app_service_name_prefix}-dev-${random_integer.app_service_name_suffix.result}"
-  location            = "${azurerm_resource_group.spacegame.location}"
-  resource_group_name = "${azurerm_resource_group.spacegame.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.spacegame.id}"
+  location            = azurerm_resource_group.spacegame.location
+  resource_group_name = azurerm_resource_group.spacegame.name
+  app_service_plan_id = azurerm_app_service_plan.spacegame.id
 
   site_config {
     linux_fx_version = "DOTNETCORE|3.1"
@@ -60,10 +65,10 @@ resource "azurerm_app_service" "spacegame_dev" {
 }
 
 output "appservice_name_dev" {
-  value       = "${azurerm_app_service.spacegame_dev.name}"
+  value       = azurerm_app_service.spacegame_dev.name
   description = "The App Service name for the dev environment"
 }
 output "website_hostname_dev" {
-  value       = "${azurerm_app_service.spacegame_dev.default_site_hostname}"
+  value       = azurerm_app_service.spacegame_dev.default_site_hostname
   description = "The hostname of the website in the dev environment"
 }


### PR DESCRIPTION
Starting from azurerm 2.0.0, it is required to include the "features" in the provider block, failing with the "terraform plan" fails with the error:

Error: "features": required field is not set

The interpolation syntax also changed from Terraform 0.11.